### PR TITLE
FIX: prevent scroll jumping by defeating ads on topic revisit

### DIFF
--- a/javascripts/discourse/components/livewrapped-ad.gjs
+++ b/javascripts/discourse/components/livewrapped-ad.gjs
@@ -33,7 +33,7 @@ export default class LivewrappedAd extends Component {
 
   @action
   async refreshAd() {
-    if (isTesting() || this.args.adIndex < 1 || this.args.adIndex === null || this.args.adIndex === undefined) {
+    if (isTesting() || this.args?.currentPostNumber > 1 || this.args.adIndex < 1 || this.args.adIndex === null || this.args.adIndex === undefined) {
       return; // Don't load external JS during tests
     };
     await loadScript(LIVEWRAPPED_SCRIPT_SRC + "?pid=" + settings.house_ads_livewrapped_source_script_pid, {
@@ -50,7 +50,7 @@ export default class LivewrappedAd extends Component {
 
   @action
   async triggerAd() {
-    if (isTesting() || this.args.adIndex < 1 || this.args.adIndex === null || this.args.adIndex === undefined) {
+    if (isTesting() || this.args?.currentPostNumber > 1 || this.args.adIndex < 1 || this.args.adIndex === null || this.args.adIndex === undefined) {
       return; // Don't load external JS during tests
     };
     await loadScript(LIVEWRAPPED_SCRIPT_SRC + "?pid=" + settings.house_ads_livewrapped_source_script_pid, {

--- a/javascripts/discourse/initializers/house-ads-livewrapped-init.js.es6
+++ b/javascripts/discourse/initializers/house-ads-livewrapped-init.js.es6
@@ -1,4 +1,3 @@
-import { debug } from "@glimmer/validator";
 import discourseComputed from "discourse-common/utils/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
@@ -29,7 +28,7 @@ export default {
         isValidAdSpot() {
           const adIndexIsValid = this.adIndex !== undefined && this.adIndex !== null && this.adIndex !== 0;
           const isFirstOrUndefinedPost = this.attrs?.current_post_number?.value === undefined || this.attrs?.current_post_number?.value === 1;
-          
+
           if (adIndexIsValid && isFirstOrUndefinedPost) {
             return 'active-ad-location';
           }

--- a/javascripts/discourse/initializers/house-ads-livewrapped-init.js.es6
+++ b/javascripts/discourse/initializers/house-ads-livewrapped-init.js.es6
@@ -1,3 +1,4 @@
+import { debug } from "@glimmer/validator";
 import discourseComputed from "discourse-common/utils/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
@@ -24,13 +25,15 @@ export default {
         pluginId: PLUGIN_ID,
         classNameBindings: ['isValidAdSpot'],
 
-        @discourseComputed("adIndex")
+        @discourseComputed("adIndex", "attrs.current_post_number", "attrs")
         isValidAdSpot() {
-          if (this.adIndex !== undefined && this.adIndex !== null && this.adIndex !== 0) {
+          const adIndexIsValid = this.adIndex !== undefined && this.adIndex !== null && this.adIndex !== 0;
+          const isFirstOrUndefinedPost = this.attrs?.current_post_number?.value === undefined || this.attrs?.current_post_number?.value === 1;
+          
+          if (adIndexIsValid && isFirstOrUndefinedPost) {
             return 'active-ad-location';
-          } else {
-            return 'inactive-ad-location';
           }
+          return 'inactive-ad-location';
         },
 
         @discourseComputed("postNumber","highest_post_number")

--- a/javascripts/discourse/templates/components/ad-slot.hbs
+++ b/javascripts/discourse/templates/components/ad-slot.hbs
@@ -8,6 +8,7 @@
       listLoading=listLoading
       postNumber=postNumber
       highest_post_number=highest_post_number
+      current_post_number=current_post_number
       indexNumber=indexNumber
       tagName=childTagName
     }}

--- a/javascripts/discourse/templates/components/house-ad.hbs
+++ b/javascripts/discourse/templates/components/house-ad.hbs
@@ -1,4 +1,4 @@
 {{#if showAd}}
-  <LivewrappedAd @tagId={{this.tagIdDesktop}} @adIndex={{this.adIndex}} @adClass={{theme-i18n 'house_ads_livewrapped_desktop_classes'}}/>
-  <LivewrappedAd @tagId={{this.tagIdMobile}}  @adIndex={{this.adIndex}} @adClass={{theme-i18n 'house_ads_livewrapped_mobile_classes'}}/>
+  <LivewrappedAd @tagId={{this.tagIdDesktop}} @adIndex={{this.adIndex}} @currentPostNumber={{@current_post_number}} @adClass={{theme-i18n 'house_ads_livewrapped_desktop_classes'}}/>
+  <LivewrappedAd @tagId={{this.tagIdMobile}}  @adIndex={{this.adIndex}} @currentPostNumber={{@current_post_number}} @adClass={{theme-i18n 'house_ads_livewrapped_mobile_classes'}}/>
 {{/if}}

--- a/javascripts/discourse/templates/components/post-bottom-ad.hbs
+++ b/javascripts/discourse/templates/components/post-bottom-ad.hbs
@@ -1,6 +1,7 @@
 {{ad-slot
   placement="post-bottom"
   highest_post_number=@model.topicPostsCount
+  current_post_number=@model.topic.current_post_number
   category=@model.topic.category.slug
   postNumber=@model.post_number
 }}


### PR DESCRIPTION
Ads rendering between Posts are causing a clash with core Post scrolling logic during infinite scroll refresh events.  This only seems to happen during re-visits to Topics, so as a workaround, this change removes between-Post ads when the user is revisiting a Topic.